### PR TITLE
Update Adam epsilon value in model card from 1e-4 to 1e-5

### DIFF
--- a/models/t4-llama-2-70b.md
+++ b/models/t4-llama-2-70b.md
@@ -30,7 +30,7 @@
 |Initial learning rate|1e-4|
 |Beta1|0.9|
 |Beta2|0.95|
-|Epsilon|1e-4|
+|Epsilon|1e-5|
 |Warmup strategy|Linear|
 |Warmup steps|2000|
 |Learning rate scheduling strategy|Cosine|


### PR DESCRIPTION
[Llama-2論文](https://arxiv.org/pdf/2307.09288) の設定と同様に、Adam epsilonには1E-5を採用するつもりでジョブスクリプト、モデルカードを作成していましたが、モデルカードのみtemplate.mdの値を変え忘れ1E-4としていました。
モデルカードと実際のジョブスクリプトの相違に気づかず、申し訳ありません。
この場合、今流しているjobはそのまま流し続けることになります。