### PR TITLE
Add Z loss info and fix token number for the 70B model on TSUBAME4

### DIFF
--- a/models/t4-llama-2-70b.md
+++ b/models/t4-llama-2-70b.md
@@ -19,7 +19,7 @@
 |Spec name|Value|
 |:---|:---|
 |Dataset|LLM-jp v3|
-|Number of tokens|2.1T|
+|Number of tokens|2,117,241,409,943 Token|
 
 # Training specs
 
@@ -40,6 +40,7 @@
 |Dropout rate|0.0|
 |Floating point precisions|BF16|
 |Additional randomness/approximation|Flash Attention|
+|Z loss|1e-4|
 
 # Environmental specs
 


### PR DESCRIPTION
TSUBAME4で行っている、70Bモデルについて、設定において、Z lossについての追加と、LLM-jp v3のトークン数の修正を行いました。