### PR TITLE
Add v3 3.8b card

### DIFF
--- a/models/v3-3.8b-exp1.md
+++ b/models/v3-3.8b-exp1.md
@@ -1,0 +1,65 @@
+# LLM-jp v3 3.8B experiment 1
+
+# Model specs
+
+|Spec name|Value|
+|:---|:---|
+|Base model structure|Llama-2|
+|Number of layers|28|
+|Number of embedding units(hidden size)|3072|
+|Number of FFN hidden units(intermediate size)|8192|
+|Number of attention heads|24|
+|Vocabulary size|99,487|
+|Tokenizer|[llm-jp-tokenizer-100k.ver3.0b1.model](https://github.com/llm-jp/llm-jp-tokenizer/blob/870a27ce6872e105e4b76cdf2e68c8b7ebfc6a37/models/ver3.0/llm-jp-tokenizer-100k.ver3.0b1.model)|
+|Maximum sequence length|4096|
+|Positional embedding|RoPE|
+
+# Dataset specs
+|Spec name|Value|
+|:---|:---|
+|Dataset|LLM-jp v3.1|
+|Number of tokens|2,072,488,058,295|
+
+# Training specs
+
+|Spec name|Value|
+|:---|:---|
+|Implementation|[Megatron-LM](https://github.com/llm-jp/Megatron-LM/tree/936f55676ee8d8f329a3fe12f5c4e7fdc51b46f8)|
+|Optimizer|AdamW|
+|Initial learning rate|3e-4|
+|Final learning rate|3e-5|
+|Beta1|0.9|
+|Beta2|0.95|
+|Epsilon|1e-8|
+|Weight decay factor|0.1|
+|Warmup strategy|Linear|
+|Warmup steps|2000|
+|Learning rate scheduling strategy|Cosine|
+|Learning rate scheduling steps|492120|
+|Total training steps|494120|
+|Global batch size|1,024|
+|Dropout rate|0.0|
+|Floating point precisions|BF16|
+|Additional randomness/approximation|Flash Attention|
+|Z loss|1e-4|
+|Embedding scale|❌|
+|Tensor parallel size|1|
+|Pipeline parallel size|1|
+
+
+# Environmental specs
+
+|Spec name|Value|
+|:---|:---|
+|Data center|Sakura (Ishikari)|
+|Number of Nodes|8|
+|Processor|Intel(R) Xeon(R) Platinum 8480+|
+|Number of CPUs per instance|56|
+|RAM|2.0 TiB|
+|Accelerators|NVIDIA H100 80GB|
+|Number of accelerators per instance|16|
+|Intra Node Communication |NVLink|
+
+# Comments
+
+学習データはGENIAC 172Bモデルと同様であるため、GENIAモデルのモデルサイズ縮小版としての性格をもちます。


### PR DESCRIPTION
v3 3.8Bモデル（約3.782B params）の仕様です。1.7Bと13Bの間を埋める仕様にしています。