### PR TITLE
Add v3-1.7B CPT 1-3 mode cards

### DIFF
--- a/models/v3-1.7b-cpt1_3.md
+++ b/models/v3-1.7b-cpt1_3.md
@@ -1,0 +1,63 @@
+# LLM-jp v3 1.7B continual pretrain experiment 1[A-D] and 2[A-D] and 3 
+
+# Model specs
+
+|Spec name|Value|
+|:---|:---|
+|Base model structure|Llama-2|
+|Base model before CPT|[v3-1.7b-exp2 Iter988k](https://github.com/llm-jp/model-cards/blob/main/models/v3-1.7b-exp2.md)|
+|Number of layers|24|
+|Number of embedding units(hidden size)|2048|
+|Number of FFN hidden units(intermediate size)|7168|
+|Number of attention heads|16|
+|Vocabulary size|99,487|
+|Tokenizer|[llm-jp-tokenizer-100k.ver3.0b1.model](https://github.com/llm-jp/llm-jp-tokenizer/blob/870a27ce6872e105e4b76cdf2e68c8b7ebfc6a37/models/ver3.0/llm-jp-tokenizer-100k.ver3.0b1.model)|
+|Maximum sequence length|4096|
+|Positional embedding|RoPE|
+
+# Dataset specs
+|Spec name|Value|
+|:---|:---|
+|Dataset|LLM-jp v3.1|
+|Number of tokens|210,000,000,000|
+
+# Training specs
+
+|Spec name|Value|
+|:---|:---|
+|Implementation|[Megatron-LM](https://github.com/llm-jp/Megatron-LM/tree/39135acf57aee423ec6ead34748bdd405793ca38)|
+|Optimizer|AdamW|
+|Initial learning rate|3e-5|
+|Final learning rate|3e-5|
+|Beta1|0.9|
+|Beta2|0.95|
+|Epsilon|1e-8|
+|Weight decay factor|0.1|
+|Warmup strategy|Linear|
+|Warmup steps|0|
+|Learning rate scheduling strategy|Constant|
+|Learning rate scheduling steps|100,135|
+|Total training steps|100,135|
+|Global batch size|512|
+|Dropout rate|0.0|
+|Floating point precisions|BF16|
+|Additional randomness/approximation|Flash Attention|
+|Z loss|1e-4|
+|Embedding scale|❌|
+|Tensor parallel size|1|
+|Pipeline parallel size|1|
+
+# Environmental specs
+
+|Spec name|Value|
+|:---|:---|
+|Data center|Sakura Internet|
+|Number of Nodes|16|
+|Processor|Intel Xeon Platinum 8480 Processor (56core, 2.0GHz)|
+|Number of processors per instance|2|
+|RAM|2.0TB|
+|Accelerators|NVIDIA H100 80GB|
+|Number of accelerators per instance|8|
+|Intra Node Communication |NVLink|
+
+# Comments


### PR DESCRIPTION
This PR adds model cards for the pre-trained model 1.7B-exp2 using high-quality data.